### PR TITLE
updated #removePoint function

### DIFF
--- a/js/graphEditor.js
+++ b/js/graphEditor.js
@@ -49,7 +49,10 @@ class GraphEditor   {
         this.graph.removePoint(point)
         //set up the hovered/selected var back to null to prevent keeping the selected/hovered point 
         this.hovered = null;
-        this.selected = null;
+        //point only goes back to null when the selected point is targetted to be removed.
+        if (this.selected == point){
+            this.selected = null;
+        }
     }
 
    


### PR DESCRIPTION
before: when a point is being removed, all of the points' selected var goes back to null. 
After: When a point is being removed, only the targetted point's selected var goes back to null. 