### PR TITLE
fixed error when the mouse coordinate and the actual point doesn't match

### DIFF
--- a/js/viewport.js
+++ b/js/viewport.js
@@ -23,8 +23,8 @@ class Viewport  {
     //Get the coordinate of the mouse postion and apply the zoom scale.
     getMouse(evt)   {
         return new Point(
-            evt.offsetX * this.zoom,
-            evt.offsetY * this.zoom
+            (evt.offsetX - this.center.x) * this.zoom - this.offset.x,
+            (evt.offsetY - this.center.y) * this.zoom - this.offset.y
         )
     }
     //Function to comopute the current offset by adding the initial offset to the offset change due to dragging


### PR DESCRIPTION
Because we manually changed the center of the offset, we have to subtract the center coordinates from the mouse coordinates and apply the zoom scale to make sure the mouse and the actual point in the canvas matches up 